### PR TITLE
fix: open JSON files as UTF-8 in batch_infer.py (avoiding Windows locale crash)

### DIFF
--- a/batch_infer.py
+++ b/batch_infer.py
@@ -74,13 +74,13 @@ def load(model_id, device):
     else:
         cfg_path = hf_hub_download(model_id, "config.json")
         weights_path = hf_hub_download(model_id, "model.safetensors")
-    cfg = json.load(open(cfg_path))
+    cfg = json.load(open(cfg_path, encoding="utf-8"))
     model = FreyaDiT(vocab=cfg["vocab"], d=cfg["d"], depth=cfg["depth"],
                      heads=cfg["heads"], ff=cfg["ff"]).to(device).eval()
     model.load_state_dict(load_file(weights_path), strict=True)
     vae = load_audio_vae(device)
     vocab_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "freyatts", "char_vocab.json")
-    char_to_id = json.load(open(vocab_path))
+    char_to_id = json.load(open(vocab_path, encoding="utf-8"))
     return model, vae, char_to_id
 
 


### PR DESCRIPTION
Congratulations on the release. It's a proud moment for Turkish ML/AI community. I experimented with FreyaTTS on varying stacks, spent most of my time with the batched inference path, and it worked like a charm. Given that it's a 183M params model, a very solid foundation you gave us to build upon.

I ran into a little problem while trying this out though. I believe it could be helpful for the rare species like me who still works on Windows devices :)

The batch_infer.py opens config.json and char_vocab.json without an explicit encoding. I suppose that is not necessarily a problem for MacOS/Linux systems. On Windows, however, Python falls back to the system locale codepage — cp1254 on Turkish systems — which crashes with a UnicodeDecodeError when reading char_vocab.json, before inference starts. By the way, it's the Turkish character vocabulary that trips on Turkish Windows machines. At least, this was what I experienced in multiple Windows devices.

This PR suggests passing encoding="utf-8" explicitly to both open() calls. No behavior change on Linux/macOS. Seemingly a minor issue yet I was not able to run inference until figuring this out.

Thanks for open-sourcing this. It fills a real gap for Turkish voice AI efforts. Hope the very best for the entire team!
